### PR TITLE
Use MySQL on port 3309

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       MYSQL_USER: app
       MYSQL_PASSWORD: app
     ports:
-      - "3306:3306"
+      - "3309:3306"
     volumes:
       - db_data:/var/lib/mysql
 

--- a/phinx.php
+++ b/phinx.php
@@ -14,7 +14,7 @@ return [
             'name' => 'nome_do_banco',
             'user' => 'root',
             'pass' => 'senha',
-            'port' => '3306',
+            'port' => '3309',
             'charset' => 'utf8mb4',
         ],
     ],


### PR DESCRIPTION
## Summary
- change MySQL host port to `3309` in `docker-compose.yml`
- update migration config to use port `3309`

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686db0b4ac74832ca0f51b8e46b45f19