### PR TITLE
Move Database class to Infrastructure namespace

### DIFF
--- a/src/Infrastructure/Database/Database.php
+++ b/src/Infrastructure/Database/Database.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App;
+namespace Infrastructure\Database;
 
 use PDO;
 
@@ -24,4 +24,5 @@ class Database
         ]);
 
         return $pdo;
-    }}
+    }
+}

--- a/src/Infrastructure/Framework/Config/dependencies.php
+++ b/src/Infrastructure/Framework/Config/dependencies.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use DI\Container;
-use App\Database;
+use Infrastructure\Database\Database;
 use Domain\Produto\ProdutoRepository;
 use Infrastructure\Persistence\PdoProdutoRepository;
 use PDO;


### PR DESCRIPTION
## Summary
- move `Database.php` into `src/Infrastructure/Database`
- update namespace to `Infrastructure\Database`
- adjust DI container config

## Testing
- `php -v` *(fails: command not found)*
- `composer dump-autoload` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dca7565b0832c8ca16b9afb37889f