### PR TITLE
Implement JWT auth and user CRUD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ DB_HOST=db
 DB_NAME=app
 DB_USER=root
 DB_PASS=password
+JWT_SECRET=secret

--- a/database/migrations/20250707222600_create_users_table.php
+++ b/database/migrations/20250707222600_create_users_table.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateUsersTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $table = $this->table('users');
+        $table->addColumn('login', 'string', ['limit' => 255])
+            ->addColumn('email', 'string', ['limit' => 255])
+            ->addColumn('nome', 'string', ['limit' => 255])
+            ->addColumn('senha', 'string', ['limit' => 255])
+            ->addIndex(['login'], ['unique' => true])
+            ->create();
+    }
+}

--- a/src/Application/Usuario/AtualizarUsuario.php
+++ b/src/Application/Usuario/AtualizarUsuario.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Application\\Usuario;
+
+use Domain\\Usuario\\Usuario;
+use Domain\\Usuario\\UsuarioRepository;
+
+class AtualizarUsuario
+{
+    public function __construct(private UsuarioRepository $repository)
+    {
+    }
+
+    public function execute(int $id, string $login, string $email, string $nome, string $senha): ?Usuario
+    {
+        $usuario = $this->repository->findById($id);
+        if (!$usuario) {
+            return null;
+        }
+        $usuario->setLogin($login);
+        $usuario->setEmail($email);
+        $usuario->setNome($nome);
+        $usuario->setSenha($senha);
+        $this->repository->update($usuario);
+        return $usuario;
+    }
+}

--- a/src/Application/Usuario/AutenticarUsuario.php
+++ b/src/Application/Usuario/AutenticarUsuario.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Application\\Usuario;
+
+use Domain\\Usuario\\UsuarioRepository;
+
+class AutenticarUsuario
+{
+    public function __construct(private UsuarioRepository $repository)
+    {
+    }
+
+    public function execute(string $login, string $senha): ?int
+    {
+        $usuario = $this->repository->findByLogin($login);
+        if (!$usuario) {
+            return null;
+        }
+        if (!password_verify($senha, $usuario->getSenha())) {
+            return null;
+        }
+        return $usuario->getId();
+    }
+}

--- a/src/Application/Usuario/BuscarUsuario.php
+++ b/src/Application/Usuario/BuscarUsuario.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Application\\Usuario;
+
+use Domain\\Usuario\\UsuarioRepository;
+use Domain\\Usuario\\Usuario;
+
+class BuscarUsuario
+{
+    public function __construct(private UsuarioRepository $repository)
+    {
+    }
+
+    public function execute(int $id): ?Usuario
+    {
+        return $this->repository->findById($id);
+    }
+}

--- a/src/Application/Usuario/CriarUsuario.php
+++ b/src/Application/Usuario/CriarUsuario.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Application\\Usuario;
+
+use Domain\\Usuario\\Usuario;
+use Domain\\Usuario\\UsuarioRepository;
+
+class CriarUsuario
+{
+    public function __construct(private UsuarioRepository $repository)
+    {
+    }
+
+    public function execute(string $login, string $email, string $nome, string $senha): Usuario
+    {
+        $usuario = new Usuario(null, $login, $email, $nome, $senha);
+        return $this->repository->save($usuario);
+    }
+}

--- a/src/Application/Usuario/DeletarUsuario.php
+++ b/src/Application/Usuario/DeletarUsuario.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Application\\Usuario;
+
+use Domain\\Usuario\\UsuarioRepository;
+
+class DeletarUsuario
+{
+    public function __construct(private UsuarioRepository $repository)
+    {
+    }
+
+    public function execute(int $id): bool
+    {
+        return $this->repository->delete($id);
+    }
+}

--- a/src/Application/Usuario/ListarUsuarios.php
+++ b/src/Application/Usuario/ListarUsuarios.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Application\\Usuario;
+
+use Domain\\Usuario\\UsuarioRepository;
+
+class ListarUsuarios
+{
+    public function __construct(private UsuarioRepository $repository)
+    {
+    }
+
+    public function execute(): array
+    {
+        return $this->repository->findAll();
+    }
+}

--- a/src/Domain/Usuario/Usuario.php
+++ b/src/Domain/Usuario/Usuario.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace Domain\\Usuario;
+
+class Usuario
+{
+    public function __construct(
+        private ?int $id,
+        private string $login,
+        private string $email,
+        private string $nome,
+        private string $senha
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getLogin(): string
+    {
+        return $this->login;
+    }
+
+    public function setLogin(string $login): void
+    {
+        $this->login = $login;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): void
+    {
+        $this->email = $email;
+    }
+
+    public function getNome(): string
+    {
+        return $this->nome;
+    }
+
+    public function setNome(string $nome): void
+    {
+        $this->nome = $nome;
+    }
+
+    public function getSenha(): string
+    {
+        return $this->senha;
+    }
+
+    public function setSenha(string $senha): void
+    {
+        $this->senha = $senha;
+    }
+}

--- a/src/Domain/Usuario/UsuarioRepository.php
+++ b/src/Domain/Usuario/UsuarioRepository.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Domain\\Usuario;
+
+interface UsuarioRepository
+{
+    public function save(Usuario $usuario): Usuario;
+    public function findAll(): array;
+    public function findById(int $id): ?Usuario;
+    public function findByLogin(string $login): ?Usuario;
+    public function update(Usuario $usuario): bool;
+    public function delete(int $id): bool;
+}

--- a/src/Infrastructure/Framework/Config/dependencies.php
+++ b/src/Infrastructure/Framework/Config/dependencies.php
@@ -6,6 +6,8 @@ use DI\Container;
 use Infrastructure\Database\Database;
 use Domain\Produto\ProdutoRepository;
 use Infrastructure\Persistence\PdoProdutoRepository;
+use Domain\Usuario\UsuarioRepository;
+use Infrastructure\Persistence\PdoUsuarioRepository;
 use PDO;
 
 return function (Container $container): void {
@@ -20,4 +22,5 @@ return function (Container $container): void {
     });
 
     $container->set(ProdutoRepository::class, DI\autowire(PdoProdutoRepository::class));
+    $container->set(UsuarioRepository::class, DI\autowire(PdoUsuarioRepository::class));
 };

--- a/src/Infrastructure/Persistence/PdoUsuarioRepository.php
+++ b/src/Infrastructure/Persistence/PdoUsuarioRepository.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace Infrastructure\\Persistence;
+
+use Domain\\Usuario\\Usuario;
+use Domain\\Usuario\\UsuarioRepository;
+use PDO;
+
+class PdoUsuarioRepository implements UsuarioRepository
+{
+    public function __construct(private PDO $pdo)
+    {
+    }
+
+    public function save(Usuario $usuario): Usuario
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO users (login, email, nome, senha) VALUES (:login, :email, :nome, :senha)');
+        $stmt->execute([
+            ':login' => $usuario->getLogin(),
+            ':email' => $usuario->getEmail(),
+            ':nome' => $usuario->getNome(),
+            ':senha' => $usuario->getSenha(),
+        ]);
+        $usuario->setId((int)$this->pdo->lastInsertId());
+        return $usuario;
+    }
+
+    public function findAll(): array
+    {
+        $stmt = $this->pdo->query('SELECT id, login, email, nome, senha FROM users');
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        return array_map(fn($row) => new Usuario((int)$row['id'], $row['login'], $row['email'], $row['nome'], $row['senha']), $rows);
+    }
+
+    public function findById(int $id): ?Usuario
+    {
+        $stmt = $this->pdo->prepare('SELECT id, login, email, nome, senha FROM users WHERE id = :id');
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$row) {
+            return null;
+        }
+        return new Usuario((int)$row['id'], $row['login'], $row['email'], $row['nome'], $row['senha']);
+    }
+
+    public function findByLogin(string $login): ?Usuario
+    {
+        $stmt = $this->pdo->prepare('SELECT id, login, email, nome, senha FROM users WHERE login = :login');
+        $stmt->execute([':login' => $login]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!$row) {
+            return null;
+        }
+        return new Usuario((int)$row['id'], $row['login'], $row['email'], $row['nome'], $row['senha']);
+    }
+
+    public function update(Usuario $usuario): bool
+    {
+        $stmt = $this->pdo->prepare('UPDATE users SET login = :login, email = :email, nome = :nome, senha = :senha WHERE id = :id');
+        return $stmt->execute([
+            ':id' => $usuario->getId(),
+            ':login' => $usuario->getLogin(),
+            ':email' => $usuario->getEmail(),
+            ':nome' => $usuario->getNome(),
+            ':senha' => $usuario->getSenha(),
+        ]);
+    }
+
+    public function delete(int $id): bool
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM users WHERE id = :id');
+        return $stmt->execute([':id' => $id]);
+    }
+}

--- a/src/Presentation/Http/Controllers/AuthController.php
+++ b/src/Presentation/Http/Controllers/AuthController.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Presentation\\Http\\Controllers;
+
+use Application\\Usuario\\AutenticarUsuario;
+use Firebase\\JWT\\JWT;
+use Firebase\\JWT\\Key;
+use Psr\\Http\\Message\\ResponseInterface as Response;
+use Psr\\Http\\Message\\ServerRequestInterface as Request;
+
+class AuthController
+{
+    public function __construct(private AutenticarUsuario $autenticarUsuario)
+    {
+    }
+
+    public function login(Request $request, Response $response): Response
+    {
+        $params = (array)$request->getParsedBody();
+        $userId = $this->autenticarUsuario->execute($params['login'], $params['senha']);
+        if (!$userId) {
+            $response->getBody()->write(json_encode(['message' => 'Credenciais inválidas']));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(401);
+        }
+        $payload = [
+            'sub' => $userId,
+            'iat' => time(),
+            'exp' => time() + 3600,
+        ];
+        $token = JWT::encode($payload, $_ENV['JWT_SECRET'] ?? 'secret', 'HS256');
+        $response->getBody()->write(json_encode(['token' => $token]));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+}

--- a/src/Presentation/Http/Controllers/UsuarioController.php
+++ b/src/Presentation/Http/Controllers/UsuarioController.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace Presentation\\Http\\Controllers;
+
+use Application\\Usuario\\AtualizarUsuario;
+use Application\\Usuario\\BuscarUsuario;
+use Application\\Usuario\\CriarUsuario;
+use Application\\Usuario\\DeletarUsuario;
+use Application\\Usuario\\ListarUsuarios;
+use Psr\\Http\\Message\\ResponseInterface as Response;
+use Psr\\Http\\Message\\ServerRequestInterface as Request;
+
+class UsuarioController
+{
+    public function __construct(
+        private CriarUsuario $criarUsuario,
+        private ListarUsuarios $listarUsuarios,
+        private BuscarUsuario $buscarUsuario,
+        private AtualizarUsuario $atualizarUsuario,
+        private DeletarUsuario $deletarUsuario
+    ) {
+    }
+
+    public function index(Request $request, Response $response): Response
+    {
+        $usuarios = $this->listarUsuarios->execute();
+        $items = array_map(fn($u) => [
+            'id' => $u->getId(),
+            'login' => $u->getLogin(),
+            'email' => $u->getEmail(),
+            'nome' => $u->getNome(),
+        ], $usuarios);
+        $response->getBody()->write(json_encode($items));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    public function create(Request $request, Response $response): Response
+    {
+        $params = (array)$request->getParsedBody();
+        $senha = password_hash($params['senha'], PASSWORD_BCRYPT);
+        $usuario = $this->criarUsuario->execute($params['login'], $params['email'], $params['nome'], $senha);
+        $data = ['id' => $usuario->getId(), 'login' => $usuario->getLogin(), 'email' => $usuario->getEmail(), 'nome' => $usuario->getNome()];
+        $response->getBody()->write(json_encode($data));
+        return $response->withHeader('Content-Type', 'application/json')->withStatus(201);
+    }
+
+    public function show(Request $request, Response $response, array $args): Response
+    {
+        $id = (int)$args['id'];
+        $usuario = $this->buscarUsuario->execute($id);
+        if (!$usuario) {
+            $response->getBody()->write(json_encode(['message' => 'Usuário não encontrado']));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(404);
+        }
+        $data = ['id' => $usuario->getId(), 'login' => $usuario->getLogin(), 'email' => $usuario->getEmail(), 'nome' => $usuario->getNome()];
+        $response->getBody()->write(json_encode($data));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    public function update(Request $request, Response $response, array $args): Response
+    {
+        $id = (int)$args['id'];
+        $params = (array)$request->getParsedBody();
+        $senha = password_hash($params['senha'], PASSWORD_BCRYPT);
+        $usuario = $this->atualizarUsuario->execute($id, $params['login'], $params['email'], $params['nome'], $senha);
+        if (!$usuario) {
+            $response->getBody()->write(json_encode(['message' => 'Usuário não encontrado']));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(404);
+        }
+        $data = ['id' => $usuario->getId(), 'login' => $usuario->getLogin(), 'email' => $usuario->getEmail(), 'nome' => $usuario->getNome()];
+        $response->getBody()->write(json_encode($data));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    public function delete(Request $request, Response $response, array $args): Response
+    {
+        $id = (int)$args['id'];
+        if (!$this->deletarUsuario->execute($id)) {
+            $response->getBody()->write(json_encode(['message' => 'Usuário não encontrado']));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(404);
+        }
+        return $response->withStatus(204);
+    }
+}

--- a/src/Presentation/Http/JwtMiddleware.php
+++ b/src/Presentation/Http/JwtMiddleware.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Presentation\\Http;
+
+use Firebase\\JWT\\JWT;
+use Firebase\\JWT\\Key;
+use Psr\\Http\\Message\\ResponseInterface as Response;
+use Psr\\Http\\Message\\ServerRequestInterface as Request;
+use Psr\\Http\\Server\\MiddlewareInterface;
+use Psr\\Http\\Server\\RequestHandlerInterface as RequestHandler;
+use Slim\\Psr7\\Response as SlimResponse;
+
+class JwtMiddleware implements MiddlewareInterface
+{
+    public function process(Request $request, RequestHandler $handler): Response
+    {
+        $auth = $request->getHeaderLine('Authorization');
+        if (!str_starts_with($auth, 'Bearer ')) {
+            return $this->unauthorized();
+        }
+        $token = substr($auth, 7);
+        try {
+            JWT::decode($token, new Key($_ENV['JWT_SECRET'] ?? 'secret', 'HS256'));
+        } catch (\Throwable $e) {
+            return $this->unauthorized();
+        }
+        return $handler->handle($request);
+    }
+
+    private function unauthorized(): Response
+    {
+        $response = new SlimResponse(401);
+        $response->getBody()->write(json_encode(['message' => 'Unauthorized']));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+}

--- a/src/Presentation/Http/Routes.php
+++ b/src/Presentation/Http/Routes.php
@@ -3,14 +3,29 @@
 declare(strict_types=1);
 
 use Presentation\Http\Controllers\ProdutoController;
+use Presentation\Http\Controllers\UsuarioController;
+use Presentation\Http\Controllers\AuthController;
+use Presentation\Http\JwtMiddleware;
 use Slim\App;
 
 return function (App $app): void {
-    $app->group('/api/produtos', function ($group) {
+    $jwt = new JwtMiddleware();
+
+    $app->group('/api/produtos', function ($group) use ($jwt) {
         $group->get('', [ProdutoController::class, 'index']);
-        $group->post('', [ProdutoController::class, 'create']);
-        $group->get('/{id}', [ProdutoController::class, 'show']);
-        $group->put('/{id}', [ProdutoController::class, 'update']);
-        $group->delete('/{id}', [ProdutoController::class, 'delete']);
+        $group->post('', [ProdutoController::class, 'create'])->add($jwt);
+        $group->get('/{id}', [ProdutoController::class, 'show'])->add($jwt);
+        $group->put('/{id}', [ProdutoController::class, 'update'])->add($jwt);
+        $group->delete('/{id}', [ProdutoController::class, 'delete'])->add($jwt);
     });
+
+    $app->group('/api/usuarios', function ($group) use ($jwt) {
+        $group->get('', [UsuarioController::class, 'index'])->add($jwt);
+        $group->post('', [UsuarioController::class, 'create'])->add($jwt);
+        $group->get('/{id}', [UsuarioController::class, 'show'])->add($jwt);
+        $group->put('/{id}', [UsuarioController::class, 'update'])->add($jwt);
+        $group->delete('/{id}', [UsuarioController::class, 'delete'])->add($jwt);
+    });
+
+    $app->post('/api/auth/login', [AuthController::class, 'login']);
 };


### PR DESCRIPTION
## Summary
- add users table migration
- implement User domain, application services, and persistence
- create JWT middleware and controllers for auth and user CRUD
- wire up dependencies and routes
- update environment example

## Testing
- `php -l src/Presentation/Http/Controllers/AuthController.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686dd392ec94832caf85f85d14840d0e