### PR TITLE
Add Valitron validator to user endpoints

### DIFF
--- a/src/Application/Usuario/UsuarioValidator.php
+++ b/src/Application/Usuario/UsuarioValidator.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Usuario;
+
+use Valitron\Validator;
+
+class UsuarioValidator extends Validator
+{
+    public function __construct(array $data = [])
+    {
+        parent::__construct($data);
+
+        $this->rule('required', ['login', 'nome', 'email', 'senha']);
+        $this->rule('lengthMin', 'login', 4);
+        $this->rule('lengthMin', 'senha', 8);
+        $this->rule('email', 'email');
+    }
+}

--- a/src/Presentation/Http/Controllers/UsuarioController.php
+++ b/src/Presentation/Http/Controllers/UsuarioController.php
@@ -33,6 +33,12 @@ class UsuarioController
     public function create(Request $request, Response $response): Response
     {
         $params = (array)$request->getParsedBody();
+        $validator = new \Application\Usuario\UsuarioValidator($params);
+        if (!$validator->validate()) {
+            $response->getBody()->write(json_encode(['errors' => $validator->errors()]));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+        }
+
         $senha = password_hash($params['senha'], PASSWORD_BCRYPT);
         $usuario = $this->criarUsuario->execute($params['login'], $params['email'], $params['nome'], $senha);
         $response->getBody()->write(json_encode($usuario->toArray()));
@@ -55,6 +61,12 @@ class UsuarioController
     {
         $id = (int)$args['id'];
         $params = (array)$request->getParsedBody();
+        $validator = new \Application\Usuario\UsuarioValidator($params);
+        if (!$validator->validate()) {
+            $response->getBody()->write(json_encode(['errors' => $validator->errors()]));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+        }
+
         $senha = password_hash($params['senha'], PASSWORD_BCRYPT);
         $usuario = $this->atualizarUsuario->execute($id, $params['login'], $params['email'], $params['nome'], $senha);
         if (!$usuario) {


### PR DESCRIPTION
## Summary
- add `UsuarioValidator` to centralize validation rules
- validate data in `UsuarioController::create` and `::update`

## Testing
- `composer validate --no-check-lock` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ddcb01a38832c8b1ee908bb592967