### PR TITLE
Add Swagger documentation via swagger-php

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Após esses passos a API já estará pronta para uso em seu ambiente local.
 
 - `POST /api/auth/login` &mdash; retorna um token JWT. Utilize-o no cabeçalho `Authorization: Bearer <token>`
 - CRUD de produtos (`/api/produtos`) e de usuários (`/api/usuarios`) conforme definido em [`src/Presentation/Http/Routes.php`](src/Presentation/Http/Routes.php)
+- Documentação OpenAPI disponível em `/openapi`
 
 As rotas de criação, edição e exclusão exigem autenticação via JWT.
 

--- a/public/swagger.php
+++ b/public/swagger.php
@@ -1,0 +1,5 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+header('Content-Type: application/json');
+$openapi = \OpenApi\Generator::scan([dirname(__DIR__) . '/src']);
+echo $openapi->toJson();

--- a/src/Application/Produto/ProdutoDTO.php
+++ b/src/Application/Produto/ProdutoDTO.php
@@ -6,11 +6,26 @@ namespace Application\Produto;
 
 use Domain\Produto\Produto;
 
+/**
+ * @OA\Schema(
+ *     schema="Produto",
+ *     required={"nome","preco"}
+ * )
+ */
 class ProdutoDTO
 {
     public function __construct(
+        /**
+         * @OA\Property(example=1)
+         */
         public ?int $id,
+        /**
+         * @OA\Property(example="Produto")
+         */
         public string $nome,
+        /**
+         * @OA\Property(example=9.99)
+         */
         public float $preco
     ) {
     }

--- a/src/Application/Usuario/UsuarioDTO.php
+++ b/src/Application/Usuario/UsuarioDTO.php
@@ -5,13 +5,31 @@ declare(strict_types=1);
 namespace Application\Usuario;
 
 use Domain\Usuario\Usuario;
+/**
+ * @OA\Schema(
+ *     schema="Usuario",
+ *     required={"login","email","nome"}
+ * )
+ */
 
 class UsuarioDTO
 {
     public function __construct(
+        /**
+         * @OA\Property(example=1)
+         */
         public ?int $id,
+        /**
+         * @OA\Property(example="johndoe")
+         */
         public string $login,
+        /**
+         * @OA\Property(example="john@example.com")
+         */
         public string $email,
+        /**
+         * @OA\Property(example="John Doe")
+         */
         public string $nome
     ) {
     }

--- a/src/Presentation/Http/Controllers/ProdutoController.php
+++ b/src/Presentation/Http/Controllers/ProdutoController.php
@@ -12,6 +12,9 @@ use Application\Produto\ListarProdutos;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
+/**
+ * @OA\Tag(name="Produtos")
+ */
 class ProdutoController
 {
     public function __construct(
@@ -23,6 +26,10 @@ class ProdutoController
     ) {
     }
 
+    /**
+     * @OA\Get(path="/api/produtos", tags={"Produtos"})
+     * @OA\Response(response=200, description="Lista de produtos")
+     */
     public function index(Request $request, Response $response): Response
     {
         $query = $request->getQueryParams();
@@ -38,6 +45,11 @@ class ProdutoController
         return $response->withHeader('Content-Type', 'application/json');
     }
 
+    /**
+     * @OA\Post(path="/api/produtos", tags={"Produtos"})
+     * @OA\RequestBody(@OA\JsonContent(ref="#/components/schemas/Produto"))
+     * @OA\Response(response=201, description="Produto criado", @OA\JsonContent(ref="#/components/schemas/Produto"))
+     */
     public function create(Request $request, Response $response): Response
     {
         $params = (array)$request->getParsedBody();
@@ -46,6 +58,12 @@ class ProdutoController
         return $response->withHeader('Content-Type', 'application/json')->withStatus(201);
     }
 
+    /**
+     * @OA\Get(path="/api/produtos/{id}", tags={"Produtos"})
+     * @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"))
+     * @OA\Response(response=200, description="Produto")
+     * @OA\Response(response=404, description="Não encontrado")
+     */
     public function show(Request $request, Response $response, array $args): Response
     {
         $id = (int)$args['id'];
@@ -58,6 +76,13 @@ class ProdutoController
         return $response->withHeader('Content-Type', 'application/json');
     }
 
+    /**
+     * @OA\Put(path="/api/produtos/{id}", tags={"Produtos"})
+     * @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"))
+     * @OA\RequestBody(@OA\JsonContent(ref="#/components/schemas/Produto"))
+     * @OA\Response(response=200, description="Produto atualizado")
+     * @OA\Response(response=404, description="Não encontrado")
+     */
     public function update(Request $request, Response $response, array $args): Response
     {
         $id = (int)$args['id'];
@@ -71,6 +96,12 @@ class ProdutoController
         return $response->withHeader('Content-Type', 'application/json');
     }
 
+    /**
+     * @OA\Delete(path="/api/produtos/{id}", tags={"Produtos"})
+     * @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"))
+     * @OA\Response(response=204, description="Excluído")
+     * @OA\Response(response=404, description="Não encontrado")
+     */
     public function delete(Request $request, Response $response, array $args): Response
     {
         $id = (int)$args['id'];

--- a/src/Presentation/Http/Controllers/UsuarioController.php
+++ b/src/Presentation/Http/Controllers/UsuarioController.php
@@ -11,6 +11,9 @@ use Application\Usuario\ListarUsuarios;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
+/**
+ * @OA\Tag(name="Usuarios")
+ */
 class UsuarioController
 {
     public function __construct(
@@ -22,6 +25,10 @@ class UsuarioController
     ) {
     }
 
+    /**
+     * @OA\Get(path="/api/usuarios", tags={"Usuarios"})
+     * @OA\Response(response=200, description="Lista de usuarios")
+     */
     public function index(Request $request, Response $response): Response
     {
         $usuarios = $this->listarUsuarios->execute();
@@ -30,6 +37,11 @@ class UsuarioController
         return $response->withHeader('Content-Type', 'application/json');
     }
 
+    /**
+     * @OA\Post(path="/api/usuarios", tags={"Usuarios"})
+     * @OA\RequestBody(@OA\JsonContent(ref="#/components/schemas/Usuario"))
+     * @OA\Response(response=201, description="Usuario criado", @OA\JsonContent(ref="#/components/schemas/Usuario"))
+     */
     public function create(Request $request, Response $response): Response
     {
         $params = (array)$request->getParsedBody();
@@ -44,6 +56,12 @@ class UsuarioController
         $response->getBody()->write(json_encode($usuario->toArray()));
         return $response->withHeader('Content-Type', 'application/json')->withStatus(201);
     }
+    /**
+     * @OA\Get(path="/api/usuarios/{id}", tags={"Usuarios"})
+     * @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"))
+     * @OA\Response(response=200, description="Usuario")
+     * @OA\Response(response=404, description="Não encontrado")
+     */
 
     public function show(Request $request, Response $response, array $args): Response
     {
@@ -57,6 +75,13 @@ class UsuarioController
         return $response->withHeader('Content-Type', 'application/json');
     }
 
+    /**
+     * @OA\Put(path="/api/usuarios/{id}", tags={"Usuarios"})
+     * @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"))
+     * @OA\RequestBody(@OA\JsonContent(ref="#/components/schemas/Usuario"))
+     * @OA\Response(response=200, description="Usuario atualizado")
+     * @OA\Response(response=404, description="Não encontrado")
+     */
     public function update(Request $request, Response $response, array $args): Response
     {
         $id = (int)$args['id'];
@@ -77,6 +102,12 @@ class UsuarioController
         return $response->withHeader('Content-Type', 'application/json');
     }
 
+    /**
+     * @OA\Delete(path="/api/usuarios/{id}", tags={"Usuarios"})
+     * @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer"))
+     * @OA\Response(response=204, description="Excluído")
+     * @OA\Response(response=404, description="Não encontrado")
+     */
     public function delete(Request $request, Response $response, array $args): Response
     {
         $id = (int)$args['id'];

--- a/src/Presentation/Http/Routes.php
+++ b/src/Presentation/Http/Routes.php
@@ -6,6 +6,7 @@ use Presentation\Http\Controllers\ProdutoController;
 use Presentation\Http\Controllers\UsuarioController;
 use Presentation\Http\Controllers\AuthController;
 use Presentation\Http\JwtMiddleware;
+use OpenApi\Generator;
 use Slim\App;
 
 return function (App $app): void {
@@ -28,4 +29,10 @@ return function (App $app): void {
     });
 
     $app->post('/api/auth/login', [AuthController::class, 'login']);
+
+    $app->get('/openapi', function ($request, $response) {
+        $openapi = Generator::scan([dirname(__DIR__, 2)]);
+        $response->getBody()->write($openapi->toJson());
+        return $response->withHeader('Content-Type', 'application/json');
+    });
 };

--- a/src/Presentation/Http/Swagger.php
+++ b/src/Presentation/Http/Swagger.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * @OA\Info(
+ *     title="Slim REST API",
+ *     version="1.0.0"
+ * )
+ */


### PR DESCRIPTION
## Summary
- add OpenAPI info holder
- describe Produto and Usuario DTOs using annotations
- document controllers with Swagger annotations
- expose `/openapi` route and helper script
- mention docs in README

## Testing
- `php -l src/Presentation/Http/Controllers/ProdutoController.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686de59053dc832cba26418234d57b29